### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wf_todos.yml
+++ b/.github/workflows/wf_todos.yml
@@ -128,6 +128,8 @@ jobs:
 
   consulta-commits-action:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Consulta commits usando action personalizada
         id: consulta_commits


### PR DESCRIPTION
Potential fix for [https://github.com/manuveta/workflow/security/code-scanning/5](https://github.com/manuveta/workflow/security/code-scanning/5)

To fix the issue, add a `permissions` block to the `consulta-commits-action` job. This block should explicitly limit the `GITHUB_TOKEN` permissions to the minimum required for the job. Since the job fetches commits using a custom action, the `contents: read` permission is sufficient.

The changes will be made in the `.github/workflows/wf_todos.yml` file, specifically within the `consulta-commits-action` job definition. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
